### PR TITLE
add mb-metadata support

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,10 @@ const nextConfig = {
             key: "Access-Control-Allow-Methods",
             value: "GET,POST,PUT,DELETE,OPTIONS",
           },
-          { key: "Access-Control-Allow-Headers", value: "Content-Type" },
+          {
+            key: "Access-Control-Allow-Headers",
+            value: "Content-Type, Authorization, mb-metadata",
+          },
         ],
       },
     ];

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "concurrently": "9.1.2",
     "eslint": "^9.19.0",
     "eslint-config-next": "15.1.6",
-    "make-agent": "0.2.9",
+    "make-agent": "latest",
     "postcss": "^8.5.1",
     "tailwindcss": "^4.0.3",
     "@tailwindcss/postcss": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "concurrently": "9.1.2",
     "eslint": "^9.19.0",
     "eslint-config-next": "15.1.6",
-    "make-agent": "latest",
+    "make-agent": "0.2.10",
     "postcss": "^8.5.1",
     "tailwindcss": "^4.0.3",
     "@tailwindcss/postcss": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         specifier: 15.1.6
         version: 15.1.6(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       make-agent:
-        specifier: 0.2.9
+        specifier: latest
         version: 0.2.9(@types/node@22.13.0)(openapi-types@12.1.3)
       postcss:
         specifier: ^8.5.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: 15.1.6
         version: 15.1.6(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)
       make-agent:
-        specifier: latest
-        version: 0.2.9(@types/node@22.13.0)(openapi-types@12.1.3)
+        specifier: 0.2.10
+        version: 0.2.10(@types/node@22.13.0)(openapi-types@12.1.3)
       postcss:
         specifier: ^8.5.1
         version: 8.5.1
@@ -1973,8 +1973,8 @@ packages:
   lru_map@0.4.1:
     resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
 
-  make-agent@0.2.9:
-    resolution: {integrity: sha512-K4/en+Z2NbI88NdlXdv+7lJ+p0//Onh+lkrjm5++CdEpcBKFGZOe+F5CiuKejsfgslKlVP8bJqbcwkiwGXEt3Q==}
+  make-agent@0.2.10:
+    resolution: {integrity: sha512-Ky0a+Yc5arB363KWF73qrmeA5RZFYk0rpOfF/N79HA7CYaSetkwglQHAgaHhjgUlNr0r3Db/Vy//L7/TOC3hiQ==}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -5354,7 +5354,7 @@ snapshots:
 
   lru_map@0.4.1: {}
 
-  make-agent@0.2.9(@types/node@22.13.0)(openapi-types@12.1.3):
+  make-agent@0.2.10(@types/node@22.13.0)(openapi-types@12.1.3):
     dependencies:
       '@apidevtools/swagger-parser': 10.1.1(openapi-types@12.1.3)
       ajv: 8.17.1


### PR DESCRIPTION
make-agent version "latest" should be set to the new release 0.2.10 before merging this PR.